### PR TITLE
Fix error message

### DIFF
--- a/main.py
+++ b/main.py
@@ -27,7 +27,7 @@ class Application(tk.Frame):
             try:
                 amount = int(accountAmount)
             except ValueError:
-                print(f'Please input a number not {str(amount)}')
+                print(f'Please input a number not {str(accountAmount)}')
             else:
                 print(f'Launching {amount} Runescape clients')
                 for mainLoop in range(int(amount)):
@@ -42,7 +42,7 @@ class Application(tk.Frame):
             try:
                 amount = int(accountAmount)
             except ValueError:
-                print(f'Please input a number not {str(amount)}')
+                print(f'Please input a number not {str(accountAmount)}')
             else:
                 for mainLoop in range(amount):
                     os.system('runescape-launcher') # This should launch runescape launcher on Debian distros, Using the Download guide of Runescape.com/download
@@ -56,7 +56,7 @@ class Application(tk.Frame):
             try:
                 amount = int(accountAmount)
             except ValueError:
-                print(f'Please input a number not {str(amount)}')
+                print(f'Please input a number not {str(accountAmount)}')
             else:
                 for mainLoop in range(amount):
                     os.system("open -n -a Runescape")


### PR DESCRIPTION
Otherwise if you input a non-integer, you get an UnboundLocalError:
```
Exception in Tkinter callback
Traceback (most recent call last):
  File "rslauncher.py", line 57, in MacOs_Launcher
    amount = int(accountAmount)
ValueError: invalid literal for int() with base 10: 'q'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/tkinter/__init__.py", line 1883, in __call__
    return self.func(*args)
  File "rslauncher.py", line 74, in Runescape
    MacOs_Launcher(amount)
  File "rslauncher.py", line 59, in MacOs_Launcher
    print(f'Please input a number not {str(amount)}')
UnboundLocalError: local variable 'amount' referenced before assignment
```